### PR TITLE
[Fix] Update the way we split the string to get pinyin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tykok/cedict-dictionary",
-  "version": "2.7.11",
+  "version": "2.7.12",
   "description": "The Cedict dictionary get and format the cedict to a JSON file",
   "main": "lib/index.js",
   "files": [

--- a/src/format-cedict.ts
+++ b/src/format-cedict.ts
@@ -12,7 +12,7 @@ const pathOfJSON = `${pathOfData}/cedict.json`;
 /**
  * Used to parse the cedict file given in the zip
  */
-const parseLine = (line: string): ChineseWord | null => {
+export const parseLine = (line: string): ChineseWord | null => {
   if (!line || line === '' || line.startsWith('#')) return null;
   const splitedLine = line.split(/\/(.*)/s);
   if (splitedLine.length <= 0) return null;
@@ -23,9 +23,7 @@ const parseLine = (line: string): ChineseWord | null => {
     const characters = charAndPinyin[0].split(' ');
     const traditional = characters[0];
     const simplified = characters[1];
-    let pinyin = charAndPinyin[1];
-    pinyin = pinyin.split(' ')[0] as unknown as string;
-    pinyin = pinyin.split(']')[0] as unknown as string;
+    const pinyin = charAndPinyin[1].split(']')[0] as string;
 
     return { traditional, simplified, pinyin, english };
   } catch (e: unknown) {

--- a/src/test/format-cedict.test.ts
+++ b/src/test/format-cedict.test.ts
@@ -1,0 +1,11 @@
+import { parseLine } from '../format-cedict';
+
+describe('Check property return of dictionary function', () => {
+  it('parseLine should return the right pinyin', () => {
+    const line = '傍晚 傍晚 [bang4 wan3] /in the evening/when night falls/towards evening/at night fall/at dusk/';
+    const actual = parseLine(line);
+
+    expect(actual).toHaveProperty('pinyin');
+    expect(actual?.pinyin).toEqual('bang4 wan3');
+  });
+});


### PR DESCRIPTION
# Description

Just change the way I split the string to get pinyin character.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested ?

I add a file named `format-cedict.test.ts` who have a test who check the result for pinyin character, according to this issue #154.